### PR TITLE
bugfix for tutor2 crash

### DIFF
--- a/KlayGE/Tutorials/src/Tutor2/Tutor2.cpp
+++ b/KlayGE/Tutorials/src/Tutor2/Tutor2.cpp
@@ -102,6 +102,8 @@ void TutorFramework::OnCreate()
 
 	meshes[0] = KlayGE::MakeSharedPtr<RenderPolygon>(model, L"side_mesh");
 
+	meshes[0]->NumLods(1);
+
 	meshes[0]->AddVertexStream(0, &vertices[0], static_cast<KlayGE::uint32_t>(sizeof(vertices[0]) * vertices.size()),
 		KlayGE::VertexElement(KlayGE::VEU_Position, 0, KlayGE::EF_BGR32F), KlayGE::EAH_GPU_Read);
 
@@ -119,6 +121,7 @@ void TutorFramework::OnCreate()
 	indices2.push_back(7); indices2.push_back(5); indices2.push_back(4);
 
 	meshes[1] = KlayGE::MakeSharedPtr<RenderPolygon>(model, L"cap_mesh");
+	meshes[1]->NumLods(1);
 	meshes[1]->AddVertexStream(0, &vertices[0], static_cast<KlayGE::uint32_t>(sizeof(vertices[0]) * vertices.size()),
 		KlayGE::VertexElement(KlayGE::VEU_Position, 0, KlayGE::EF_BGR32F), KlayGE::EAH_GPU_Read);
 	meshes[1]->AddIndexStream(0, &indices2[0], static_cast<KlayGE::uint32_t>(sizeof(indices2[0]) * indices2.size()),


### PR DESCRIPTION
当执行到 StaticMesh::AddVertexStream() 时，rls_ 的 size=0，但又试图访问 rls_[0]，于是触发了 vector subscript out of range 错误