### PR TITLE
Fix the crash error in KGEConfig

### DIFF
--- a/KFL/src/Base/XMLDom.cpp
+++ b/KFL/src/Base/XMLDom.cpp
@@ -102,7 +102,8 @@ namespace KlayGE
 
 	XMLAttributePtr XMLDocument::AllocAttribString(std::string_view name, std::string_view value)
 	{
-		return MakeSharedPtr<XMLAttribute>(*doc_, name, value);
+		return MakeSharedPtr<XMLAttribute>(*doc_, std::string_view(doc_->allocate_string(name.data(), name.size()), name.size()),
+			std::string_view(doc_->allocate_string(value.data(), value.size()), value.size()));
 	}
 
 	void XMLDocument::RootNode(XMLNodePtr const & new_node)


### PR DESCRIPTION
std::to_string 的生命周期问题，导致 KGEConfig 所生成的 xml 错误，进而连续两次启动 KGEConfig 产生崩溃