### PR TITLE
Fix the error in Model Loading

### DIFF
--- a/KlayGE/Core/Src/Render/Mesh.cpp
+++ b/KlayGE/Core/Src/Render/Mesh.cpp
@@ -317,7 +317,7 @@ namespace
 
 				for (size_t mesh_index = 0; mesh_index < meshes.size(); ++ mesh_index)
 				{
-					auto& skinned_mesh = *checked_pointer_cast<SkinnedMesh>(skinned_model.Subrenderable(mesh_index));
+					auto& skinned_mesh = *checked_pointer_cast<SkinnedMesh>(meshes[mesh_index]);
 					auto const & sw_skinned_mesh = *checked_pointer_cast<SkinnedMesh>(sw_skinned_model.Subrenderable(mesh_index));
 					skinned_mesh.AttachFramePosBounds(sw_skinned_mesh.GetFramePosBounds());
 				}


### PR DESCRIPTION
在加载已蒙皮、带有骨骼动画的模型时出错（如官网上的 Archer 模型）。
调试时发现在 `FillModel `方法中，一旦 `sw_model.IsSkinned()` 为真，`auto& skinned_mesh = *checked_pointer_cast<SkinnedMesh>(skinned_model.Subrenderable(mesh_index));` 就会出错，因为此时 `skinned_model` 的 `subrenderables_` 还是空的，直到方法的最下面 `model->AssignSubrenderables(meshes.begin(), meshes.end());` 才会赋值。